### PR TITLE
feat: Add Python3 for language support

### DIFF
--- a/src/lpg/interfaces/file.py
+++ b/src/lpg/interfaces/file.py
@@ -4,9 +4,11 @@ import os
 from click import ClickException
 
 from .lang.c import CLanguageInterface
+from .lang.python3 import Python3LanguageInterface
 
 LANGUAGE_INTERFACES = {
     "c": CLanguageInterface(),
+    "python3": Python3LanguageInterface(),
 }
 
 

--- a/src/lpg/interfaces/lang/python3.py
+++ b/src/lpg/interfaces/lang/python3.py
@@ -1,0 +1,39 @@
+"""Project generator for the Python 3 language."""
+
+import re
+from .base import BaseLanguageInterface
+
+FUNCTION_SIGNATURE_PATTERN = re.compile(
+    r"^def (?P<name>\w+)\((?P<params>[\w\s,=]*)\) -> (?P<returnType>\w+):$",
+    flags=re.MULTILINE,
+)
+
+TEST_FILE_TEMPLATE = """\
+if __name__ == "__main__":
+    {params_setup}
+    result = {name}({params_call})
+    print("result:", result)
+"""
+
+class Python3LanguageInterface(BaseLanguageInterface):
+    """Implementation of the Python 3 language project template interface."""
+
+    function_signature_pattern = FUNCTION_SIGNATURE_PATTERN
+
+    def write_project_files(self, template: str):
+        """Creates the project template for Python 3."""
+
+        with open("solution.py", "w", encoding="utf-8") as file:
+            file.write(template + "\n")
+
+        params = self.groups["params"].split(", ") if self.groups["params"] else []
+        self.groups["params_setup"] = "\n    ".join(
+            f"{param.split('=')[0]} = 0" for param in params if param
+        )
+        self.groups["params_call"] = ", ".join(param.split('=')[0] for param in params)
+
+        formatted = TEST_FILE_TEMPLATE.format(**self.groups)
+
+        with open("test.py", "w", encoding="utf-8") as file:
+            file.write(formatted)
+


### PR DESCRIPTION
This PR implements support for Python 3 code generation by:

- [x] Adding Python3LanguageInterface in interfaces/lang/python3.py.
- [x] Implementing a function signature regex to parse Python function definitions.
- [x] Generating solution.py and test.py as output files.
- [x] Registering Python3LanguageInterface in interfaces/file.py to make it available via CLI.