### PR TITLE
feat: add Golang for language support

### DIFF
--- a/src/lpg/interfaces/file.py
+++ b/src/lpg/interfaces/file.py
@@ -11,9 +11,11 @@ from .lang.javascript import JavaScriptLanguageInterface
 from .lang.python import PythonLanguageInterface
 from .lang.python3 import Python3LanguageInterface
 from .lang.typescript import TypeScriptLanguageInterface
+from .lang.golang import GoLanguageInterface
 
 LANGUAGE_INTERFACES: dict[str, BaseLanguageInterface] = {
     "c": CLanguageInterface(),
+    "g": GoLanguageInterface(),
     "java": JavaLanguageInterface(),
     "javascript": JavaScriptLanguageInterface(),
     "typescript": TypeScriptLanguageInterface(),

--- a/src/lpg/interfaces/file.py
+++ b/src/lpg/interfaces/file.py
@@ -6,16 +6,16 @@ from click import ClickException
 
 from .lang.base import BaseLanguageInterface
 from .lang.c import CLanguageInterface
+from .lang.golang import GoLanguageInterface
 from .lang.java import JavaLanguageInterface
 from .lang.javascript import JavaScriptLanguageInterface
 from .lang.python import PythonLanguageInterface
 from .lang.python3 import Python3LanguageInterface
 from .lang.typescript import TypeScriptLanguageInterface
-from .lang.golang import GoLanguageInterface
 
 LANGUAGE_INTERFACES: dict[str, BaseLanguageInterface] = {
     "c": CLanguageInterface(),
-    "g": GoLanguageInterface(),
+    "golang": GoLanguageInterface(),
     "java": JavaLanguageInterface(),
     "javascript": JavaScriptLanguageInterface(),
     "typescript": TypeScriptLanguageInterface(),

--- a/src/lpg/interfaces/lang/base.py
+++ b/src/lpg/interfaces/lang/base.py
@@ -74,17 +74,28 @@ class BaseLanguageInterface(metaclass=ABCMeta):
             if match is not None
         )
 
+    def is_void_return_type(self) -> bool:
+        """Determines if the solution function return type is void. Can be overridden."""
+        return self.groups["returnType"] == "void"
+
     def get_formatted_nonvoid_template(
-        self, template: str, nonvoid_callback: Callable[[], str]
+        self,
+        template: str,
+        nonvoid_callback: Callable[[], str],
+        result_var_declaration: str | None = None,
     ) -> str:
         """Adjusts the return type and method call when the return type is void.
         Useful for C-style languages where assigning to a void variable is not allowed.
         """
-        if self.groups["returnType"] == "void":
+        if self.is_void_return_type():
             self.groups["result_var_declaration"] = ""
             self.groups["result_var"] = "0"
             return template
-        self.groups["result_var_declaration"] = f"{self.groups['returnType']} result = "
+        self.groups["result_var_declaration"] = (
+            f"{self.groups['returnType']} result = "
+            if result_var_declaration is None
+            else result_var_declaration
+        )
         self.groups["result_var"] = "result"
         return nonvoid_callback()
 

--- a/src/lpg/interfaces/lang/golang.py
+++ b/src/lpg/interfaces/lang/golang.py
@@ -105,9 +105,9 @@ class GoLanguageInterface(BaseLanguageInterface):
             return "nil"
 
         # Check for simple matches in dictionary
-        for key in switch_dict:
+        for key, value in switch_dict.items():
             if key in param_type:
-                return switch_dict[key]
+                return value
 
         return f"{param_type}{{}}"  # Default struct initialization
 

--- a/src/lpg/interfaces/lang/golang.py
+++ b/src/lpg/interfaces/lang/golang.py
@@ -1,0 +1,120 @@
+"""Project generator for the Go language."""
+
+import re
+from .base import BaseLanguageInterface
+
+# Go function signature pattern
+FUNCTION_SIGNATURE_PATTERN = re.compile(
+    r"^\s*func\s+(?P<name>\w+)\((?P<params>[^)]*)\)\s+(?P<returnType>[^{]+)\s*{",
+    flags=re.MULTILINE,
+)
+
+SOLUTION_FILE_TEMPLATE = """\
+package solution
+
+{supplemental_code}
+func {name}({params}) {returnType} {
+    // TODO: Implement solution
+    {return_statement}
+}
+"""
+
+TEST_FILE_TEMPLATE = """\
+package main
+
+import (
+    "fmt"
+    "./solution"
+)
+
+func main() {
+    // Test case setup
+    {params_setup}
+    
+    // Execute solution
+    {result_var_declaration}solution.{name}({params_call})
+    
+    // Display result
+    fmt.Printf("{OUTPUT_RESULT_PREFIX} %v\\n", {result_var})
+}
+"""
+
+
+class GoLanguageInterface(BaseLanguageInterface):
+    """Implementation of the Go language project template interface."""
+
+    function_signature_pattern = FUNCTION_SIGNATURE_PATTERN
+    compile_command = ["go", "build", "-o", "test", "test.go"]
+    test_command = ["./test"]
+    default_output = "0"
+
+    def prepare_project_files(self, template: str):
+        params = self.groups["params"].split(", ")
+        param_names = []
+        param_types = []
+
+        for param in params:
+            if not param.strip():
+                continue
+
+            parts = param.strip().split()
+            if len(parts) == 2:
+                param_names.append(parts[0])
+                param_types.append(parts[1])
+            else:
+                # Handle unnamed parameters or complex types
+                param_names.append(f"param{len(param_names)}")
+                param_types.append(param.strip())
+
+        self.groups["params_setup"] = ";\n    ".join(
+            [
+                f"{name} := {self._get_default_value(param_type)}"
+                for name, param_type in zip(param_names, param_types)
+            ]
+        )
+
+        self.groups["params_call"] = ", ".join(param_names)
+        self.groups["return_statement"] = self._get_default_return(
+            self.groups["returnType"]
+        )
+
+        # Handle non-void return types
+        formatted_template = self.get_formatted_nonvoid_template(
+            TEST_FILE_TEMPLATE, lambda: TEST_FILE_TEMPLATE
+        )
+
+        return {
+            "solution/solution.go": SOLUTION_FILE_TEMPLATE.format(**self.groups),
+            "test.go": formatted_template.format(**self.groups),
+        }
+
+    def _get_default_value(self, param_type: str) -> str:
+        """Returns a default value for the given Go type."""
+        param_type = param_type.strip()
+
+        if "int" in param_type:
+            return "0"
+        elif "float" in param_type or "double" in param_type:
+            return "0.0"
+        elif "string" in param_type:
+            return '""'
+        elif "bool" in param_type:
+            return "false"
+        elif "[]" in param_type:  # array/slice
+            return "nil"
+        elif "map" in param_type:
+            return "nil"
+        elif "*" in param_type:  # pointer
+            return "nil"
+        else:
+            return param_type + "{}"  # struct default
+
+    def _get_default_return(self, return_type: str) -> str:
+        """Returns a default return statement for the given Go return type."""
+        return_type = return_type.strip()
+
+        if return_type == "":
+            return ""  # No return for void functions
+
+        default_value = self._get_default_value(return_type)
+        return f"return {default_value}"

--- a/src/lpg/interfaces/lang/golang.py
+++ b/src/lpg/interfaces/lang/golang.py
@@ -92,22 +92,24 @@ class GoLanguageInterface(BaseLanguageInterface):
         """Returns a default value for the given Go type."""
         param_type = param_type.strip()
 
-        if "int" in param_type:
-            return "0"
-        elif "float" in param_type or "double" in param_type:
-            return "0.0"
-        elif "string" in param_type:
-            return '""'
-        elif "bool" in param_type:
-            return "false"
-        elif "[]" in param_type:  # array/slice
+        switch_dict = {
+            "int": "0",
+            "float": "0.0",
+            "double": "0.0",
+            "string": '""',
+            "bool": "false",
+        }
+
+        # Check for specific patterns
+        if "[]" in param_type or "map" in param_type or "*" in param_type:
             return "nil"
-        elif "map" in param_type:
-            return "nil"
-        elif "*" in param_type:  # pointer
-            return "nil"
-        else:
-            return param_type + "{}"  # struct default
+
+        # Check for simple matches in dictionary
+        for key in switch_dict:
+            if key in param_type:
+                return switch_dict[key]
+
+        return f"{param_type}{{}}"  # Default struct initialization
 
     def _get_default_return(self, return_type: str) -> str:
         """Returns a default return statement for the given Go return type."""

--- a/src/lpg/interfaces/lang_test.py
+++ b/src/lpg/interfaces/lang_test.py
@@ -72,7 +72,7 @@ class TestProjectGeneration(unittest.TestCase):
                 continue
             self.assertMultiLineEqual(
                 result.stdout.decode().strip(),
-                f"{OUTPUT_RESULT_PREFIX} {interface.default_output}",
+                f"{OUTPUT_RESULT_PREFIX} {interface.default_output}".strip(),
             )
 
 


### PR DESCRIPTION
This PR implements support for Golang code generation by:

 Adding Python3LanguageInterface in interfaces/lang/golang.py.
 Registering GoLanguageInterface in interfaces/file.py to make it available via CLI.